### PR TITLE
#1/googleカレンダーに対応した予定登録ボタンの作成

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,10 @@
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
-				"ms-toolsai.jupyter"
+				"ms-toolsai.jupyter",
+				"formulahendry.auto-rename-tag",
+				"ecmel.vscode-html-css",
+				"ms-python.isort"
 			]
 		}
 	},

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# schedule-api

--- a/main.py
+++ b/main.py
@@ -9,6 +9,10 @@ from fastapi.templating import Jinja2Templates
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
 
+@app.get("/")
+async def root():
+    return RedirectResponse(url="https://github.com/minna-de-hack/schedule-api")
+
 @app.get("/api")
 async def makeschedule(request: Request, title: str = "", description: str = "", dates: str = ""):
     context = {"request": request, "title": title, "description": description}
@@ -32,12 +36,7 @@ async def makeschedule(request: Request, title: str = "", description: str = "",
 
     return templates.TemplateResponse("index.html", context)
 
-@app.get("/")
-async def root():
-    return RedirectResponse(url="https://github.com/minna-de-hack/schedule-api")
-
 # http://localhost/sample/
-
 @app.get("/sample/", response_class=HTMLResponse)
 async def sample():
     return """

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import urllib.parse
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 app = FastAPI()
@@ -32,12 +31,25 @@ async def makeschedule(request: Request, title: str = "", description: str = "",
     context["url"] = baseurl + d_qs
 
     return templates.TemplateResponse("index.html", context)
-    # ie. 
-    # http://localhost/api?title=sample+title&description=Today+is+Friday+in+California&dates=20201201T120000/20201201T121000
 
 @app.get("/")
 async def root():
     return RedirectResponse(url="https://github.com/minna-de-hack/schedule-api")
+
+# http://localhost/sample/
+
+@app.get("/sample/", response_class=HTMLResponse)
+async def sample():
+    return """
+    <html>
+        <head>
+            <title>sample HTML</title>
+        </head>
+        <body>
+            <iframe style="border:0" width="400" src="http://localhost/api?title=sample+title&description=Today+is+Friday+in+California&dates=20201201T120000/20201201T121000"></iframe>
+        </body>
+    </html>
+    """
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=80)

--- a/main.py
+++ b/main.py
@@ -1,11 +1,43 @@
-from fastapi import FastAPI
+import datetime
+import urllib.parse
+
 import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+@app.get("/api")
+async def makeschedule(request: Request, title: str = "", description: str = "", dates: str = ""):
+    context = {"request": request, "title": title, "description": description}
+
+    if dates != "":
+        try:
+            start, stop = dates.split("/")
+            start = datetime.datetime.strptime(start, '%Y%m%dT%H%M%S')
+            stop = datetime.datetime.strptime(stop, '%Y%m%dT%H%M%S')
+            context["start"] = start.strftime('%Y/%m/%d %H:%M')
+            context["stop"] = stop.strftime('%Y/%m/%d %H:%M')
+        except:
+            dates = ""
+            context["start"], context["stop"] = "", ""
+
+    baseurl = "https://www.google.com/calendar/render?"
+    d = {"action" : "TEMPLATE", "text" : title,
+         "details" : description, "dates" : dates}
+    d_qs = urllib.parse.urlencode(d)
+    context["url"] = baseurl + d_qs
+
+    return templates.TemplateResponse("index.html", context)
+    # ie. 
+    # http://localhost/api?title=sample+title&description=Today+is+Friday+in+California&dates=20201201T120000/20201201T121000
 
 @app.get("/")
 async def root():
-    return {"message": "Hello World"}
+    return RedirectResponse(url="https://github.com/minna-de-hack/schedule-api")
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=80)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>scheduleAPI</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="card" style="width: 25rem; ">
+      <div class="card-body">
+        <div class="row">
+          <h5 class="card-title">{{title}}</h5>
+          {% if start!=""%}
+          <h6 class="card-subtitle mb-3 text-muted">日時 : {{start}} ~ {{stop}}</h6>
+          {% endif %}          
+          <div class="col-8">
+            {% if description!="" %}
+            <p class="text-muted">説明 : {{description}}</p>
+            {% endif %}
+          </div>
+          <div class="col-4" style="text-align: center;">
+            <div style="position:relative; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+              <a href={{url}} class="btn btn-primary">予定を登録</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe" crossorigin="anonymous"></script>
+  </body>
+</html>


### PR DESCRIPTION
```url
http://localhost/api?title=sample+title&description=Today+is+Friday+in+California&dates=20201201T120000/20201201T121000
```
で呼び出した際、次のようなボタンをインフレームとして呼び出せるようにした。

![image](https://github.com/minna-de-hack/schedule-api/assets/101625248/8f964569-83b5-43d6-a963-427c0b314d24)

これを表示するために、webサイト側に追記するべきタグは
```html
<iframe style="border:0" width="400" src="http://localhost/api?title=sample+title&description=Today+is+Friday+in+California&dates=20201201T120000/20201201T121000"></iframe>
```

![image](https://github.com/minna-de-hack/schedule-api/assets/101625248/e07e9217-7e35-4e99-9590-d71b8c7dd914)